### PR TITLE
Fix file commands according to feedbacks from mock PE

### DIFF
--- a/docs/UserGuide.adoc
+++ b/docs/UserGuide.adoc
@@ -289,7 +289,10 @@ As you encrypt the file, you may tag the file at the same time for easy referenc
 
 Format: `encrypt FILEPATH [t/TAG]...`
 
-Example: `encrypt ~/Desktop/Secret File.png t/Image`
+Example: +
+For Windows: `encrypt C:\Users\YOUR_USERNAME\Desktop\Test.txt t/personal` +
+For macOS: `encrypt /Users/YOUR_USERNAME/Desktop/Test.txt t/personal` +
+(The actual file path may differ on your OS. Hence, it is always recommended to drag the file in the input field.)
 
 ====
 --
@@ -297,7 +300,7 @@ image::tip.png[width = "20", float = "left"]
 --
 *Tip*
 
-* Instead of typing the file path, you can drag the file into the input field to easily append the file path. This also applies to other commands (e.g. `add`).
+* Instead of typing the file path, you can drag the file into the input field to easily append the file path. This also applies to other commands (e.g. `add`, `move`).
 * The app may freeze for some time if the file to be encrypted is large. Please do not force exit the app during encryption.
 * The app does not support encryption of files larger than 2GB.
 ====
@@ -339,7 +342,10 @@ As you add the file, you may tag the file at the same time for easy reference la
 
 Format: `add FILENAME [t/TAG]...`
 
-Example: `add ~/Desktop/[LOCKED] Secret File.png t/Image`
+Example: +
+For Windows: `add C:\Users\YOUR_USERNAME\Desktop\[LOCKED] Test.txt t/personal` +
+For macOS: `add /Users/YOUR_USERNAME/Desktop/[LOCKED] Test.txt t/personal` +
+(The actual file path may differ on your OS. Hence, it is always recommended to drag the file in the input field.)
 
 ====
 --
@@ -375,7 +381,7 @@ Renames an encrypted file as specified by its index number. The prefix `[LOCKED]
 
 Format: `rename INDEX TARGET_FILENAME`
 
-Example: `rename 1 Secret File.txt`
+Example: `rename 1 Test2`
 
 ====
 --
@@ -388,11 +394,14 @@ image::tip.png[width = "20", float = "left"]
 
 ==== Moving an encrypted file : `move`
 
-Moves an encrypted file as specified by its index number.
+Moves an encrypted file as specified by its index number. The target directory must be a real directory (not a shortcut, alias, symbolic link, etc.)
 
 Format: `move INDEX TARGET_DIRECTORY`
 
-Example: `move 1 ~/Documents/Secret File.png`
+Example: +
+For Windows: `move 1 C:\Users\YOUR_USERNAME\Desktop` +
+For macOS: `move 1 /Users/YOUR_USERNAME/Desktop` +
+(The actual file path may differ on your OS. Hence, it is always recommended to drag the directory in the input field.)
 
 ====
 --
@@ -412,14 +421,14 @@ To return from search results, use `list` command.
 
 Format: `find KEYWORDS...`
 
-Examples: `find Secret File`
+Example: `find Test`
 ====
 --
 image::tip.png[width = "20", float = "left"]
 --
 *Tip*
 
-* The search is case insensitive. e.g `secret file` will match `Secret File`.
+* The search is case insensitive. e.g `test` will match `Test`.
 * Both the file name and the file path are searched. Hence, you can look for files with certain types (e.g. `find .png .jpg`) or files inside certain directories (e.g. `find /Desktop`).
 ====
 

--- a/src/main/java/seedu/address/logic/commands/AddFileCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddFileCommand.java
@@ -26,7 +26,7 @@ public class AddFileCommand extends Command {
     public static final String MESSAGE_USAGE = COMMAND_WORD
             + ": Adds an encrypted file in user's file system using the specified file path.\n"
             + "Parameters: FILEPATH [t/TAG]...\n"
-            + "Example: " + COMMAND_WORD + " /Desktop/[LOCKED] Test.txt t/personal";
+            + "Example: " + COMMAND_WORD + " /Users/YOUR_USERNAME/Desktop/[LOCKED] Test.txt t/personal";
 
     public static final String MESSAGE_SUCCESS = "File added: %1$s";
     public static final String MESSAGE_FAILURE = "Cannot add file.";

--- a/src/main/java/seedu/address/logic/commands/EncryptFileCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EncryptFileCommand.java
@@ -28,7 +28,7 @@ public class EncryptFileCommand extends Command {
     public static final String MESSAGE_USAGE = COMMAND_WORD
             + ": Encrypts a file in user's file system using the specified file path.\n"
             + "Parameters: FILEPATH [t/TAG]...\n"
-            + "Example: " + COMMAND_WORD + " /Desktop/Test.txt t/personal";
+            + "Example: " + COMMAND_WORD + " /Users/YOUR_USERNAME/Desktop/Test.txt t/personal";
 
     public static final String MESSAGE_SUCCESS = "File encrypted: %1$s";
     public static final String MESSAGE_FAILURE = "File encryption failed.";

--- a/src/main/java/seedu/address/logic/commands/MoveFileCommand.java
+++ b/src/main/java/seedu/address/logic/commands/MoveFileCommand.java
@@ -25,7 +25,7 @@ public class MoveFileCommand extends Command {
     public static final String MESSAGE_USAGE = COMMAND_WORD
             + ": Move the file identified by the index number from the displayed file list.\n"
             + "Parameters: INDEX NEW_LOCATION\n"
-            + "Example: " + COMMAND_WORD + " 1 /Desktop";
+            + "Example: " + COMMAND_WORD + " 1 /Users/YOUR_USERNAME/Desktop";
 
     public static final String MESSAGE_RENAME_FILE_SUCCESS = "File moved: %1$s";
     public static final String MESSAGE_RENAME_FILE_FAILURE = "Cannot move file.";

--- a/src/main/java/seedu/address/logic/commands/MoveFileCommand.java
+++ b/src/main/java/seedu/address/logic/commands/MoveFileCommand.java
@@ -32,7 +32,8 @@ public class MoveFileCommand extends Command {
     public static final String MESSAGE_TARGET_FILE_EXISTS = "Cannot move file. "
             + "Target file already exists.\nRename %1$s and try again.";
     public static final String MESSAGE_DUPLICATE_FILE = "Target file is already in the list.";
-    public static final String MESSAGE_IS_NOT_DIRECTORY = "Target path is not a directory.";
+    public static final String MESSAGE_IS_NOT_DIRECTORY = "Target path is not a directory.\n"
+            + "Moving into shortcuts, aliases and symbolic links is not supported currently.";
 
     private final Index targetIndex;
     private final FilePath newFilePath;

--- a/src/main/java/seedu/address/logic/commands/RenameFileCommand.java
+++ b/src/main/java/seedu/address/logic/commands/RenameFileCommand.java
@@ -75,7 +75,7 @@ public class RenameFileCommand extends Command {
         }
         model.setFile(fileToRename, newFile);
 
-        return new CommandResult(String.format(MESSAGE_RENAME_FILE_SUCCESS, fileToRename));
+        return new CommandResult(String.format(MESSAGE_RENAME_FILE_SUCCESS, newFile));
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/RenameFileCommand.java
+++ b/src/main/java/seedu/address/logic/commands/RenameFileCommand.java
@@ -25,10 +25,11 @@ public class RenameFileCommand extends Command {
     public static final String MESSAGE_USAGE = COMMAND_WORD
             + ": Rename the file identified by the index number from the displayed file list.\n"
             + "Parameters: INDEX NEW_FILENAME\n"
-            + "Example: " + COMMAND_WORD + " 1 Test.txt";
+            + "Example: " + COMMAND_WORD + " 1 Test";
 
     public static final String MESSAGE_RENAME_FILE_SUCCESS = "File renamed: %1$s";
-    public static final String MESSAGE_RENAME_FILE_FAILURE = "Cannot rename file.";
+    public static final String MESSAGE_RENAME_FILE_FAILURE = "Cannot rename file.\n"
+            + "Please make sure that the target file name is acceptable by your operating system.";
     public static final String MESSAGE_TARGET_FILE_EXISTS = "Cannot rename file. "
             + "Target file already exists.\nRename %1$s and try again.";
     public static final String MESSAGE_DUPLICATE_FILE = "Target file is already in the list.";

--- a/src/main/java/seedu/address/logic/parser/MoveFileCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/MoveFileCommandParser.java
@@ -4,7 +4,6 @@ import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT
 
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.MoveFileCommand;
-import seedu.address.logic.commands.RenameFileCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.file.FilePath;
 
@@ -26,7 +25,7 @@ public class MoveFileCommandParser implements Parser<MoveFileCommand> {
             return new MoveFileCommand(index, newPath);
         } catch (ParseException pe) {
             throw new ParseException(
-                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, RenameFileCommand.MESSAGE_USAGE), pe);
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, MoveFileCommand.MESSAGE_USAGE), pe);
         }
     }
 

--- a/src/main/java/seedu/address/logic/parser/MoveFileCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/MoveFileCommandParser.java
@@ -2,6 +2,8 @@ package seedu.address.logic.parser;
 
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 
+import java.nio.file.Path;
+
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.MoveFileCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
@@ -21,7 +23,11 @@ public class MoveFileCommandParser implements Parser<MoveFileCommand> {
         try {
             String trimmedArgs = args.trim();
             Index index = ParserUtil.parseIndex(trimmedArgs.split(" ")[0]);
-            FilePath newPath = new FilePath(trimmedArgs.substring(trimmedArgs.indexOf(' ') + 1));
+            if (trimmedArgs.indexOf(' ') == -1) {
+                throw new ParseException("");
+            }
+            FilePath newPath =
+                    new FilePath(Path.of(trimmedArgs.substring(trimmedArgs.indexOf(' ') + 1)).toString());
             return new MoveFileCommand(index, newPath);
         } catch (ParseException pe) {
             throw new ParseException(

--- a/src/main/java/seedu/address/logic/parser/RenameFileCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/RenameFileCommandParser.java
@@ -21,6 +21,9 @@ public class RenameFileCommandParser implements Parser<RenameFileCommand> {
         try {
             String trimmedArgs = args.trim();
             Index index = ParserUtil.parseIndex(trimmedArgs.split(" ")[0]);
+            if (trimmedArgs.indexOf(' ') == -1) {
+                throw new ParseException("");
+            }
             FileName newName = new FileName(trimmedArgs.substring(trimmedArgs.indexOf(' ') + 1));
             return new RenameFileCommand(index, newName);
         } catch (ParseException pe) {


### PR DESCRIPTION
Fixes the following bugs:
- Change the command result file name in rename command to the new file (fixes https://github.com/AY1920S1-CS2103T-F11-3/main/issues/137)
- Correct the parsing of move and rename commands (fixes https://github.com/AY1920S1-CS2103T-F11-3/main/issues/99)

Changes the following in UG:
- Example for move file command (fixes https://github.com/AY1920S1-CS2103T-F11-3/main/issues/139)
- Examples of file paths for file commands (may fix https://github.com/AY1920S1-CS2103T-F11-3/main/issues/135) 
- Description to explain shortcuts, aliases, and symbolic links are not supported for move command (may fix https://github.com/AY1920S1-CS2103T-F11-3/main/issues/138)